### PR TITLE
Fix(#217) : 팔로잉 리스트 취소 에러 문제 처리를 위한 팔로잉/팔로워 컴포넌트 분리

### DIFF
--- a/src/components/mypage/FollowerList.tsx
+++ b/src/components/mypage/FollowerList.tsx
@@ -1,0 +1,127 @@
+import {
+  getFollowDataFollower,
+  getFollowDataFollowing,
+  updateFollow,
+} from '@/shared/mypage/api'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useSession } from 'next-auth/react'
+import React from 'react'
+import ButtonSecondary from './ButtonSecondary'
+import Link from 'next/link'
+import Image from 'next/image'
+
+type FollowProps = {
+  data: string[]
+  myFollowing?: string[]
+}
+
+const FollowerList = ({ data, myFollowing }: FollowProps) => {
+  const { data: userSessionInfo } = useSession()
+  const uid = userSessionInfo?.user?.uid as string
+  const queryClient = useQueryClient()
+
+  const {
+    data: followData,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryFn: () => getFollowDataFollower(uid),
+    queryKey: ['follower'],
+    enabled: !!uid,
+  })
+
+  const unFollowMutation = useMutation({
+    mutationFn: updateFollow,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['follower'] })
+      queryClient.invalidateQueries({ queryKey: ['mypage'] })
+      queryClient.invalidateQueries({ queryKey: ['following'] })
+    },
+  })
+
+  const onClickUnFollow = (userId: string, targetId: string) => {
+    const newData = data.filter((item) => item !== targetId)
+    const targetUserData = followData?.find(
+      (item) => item.userId === targetId,
+    )?.follower
+    const newTargetData = targetUserData?.filter((item) => item !== userId)!
+
+    unFollowMutation.mutate({
+      userId,
+      targetId,
+      followingData: newData,
+      newTargetData,
+    })
+  }
+
+  const onClickFollow = (userId: string, targetId: string) => {
+    const data = myFollowing ? myFollowing : []
+    const newData = [...data, targetId]
+    console.log(newData)
+    // debugger
+    const newTargetData = followData?.find(
+      (item) => item.userId === targetId,
+    )?.follower!
+    newTargetData?.push(userId)
+
+    unFollowMutation.mutate({
+      userId,
+      targetId,
+      followingData: newData,
+      newTargetData,
+    })
+  }
+
+  if (isError) {
+    return '에러가 발생했습니다!'
+  }
+
+  if (isLoading) {
+    return '데이터를 불러오는 중입니다.'
+  }
+
+  return (
+    <ul className='list-none'>
+      {followData?.map((item) => {
+        return (
+          <li key={item.userId} className='flex justify-between py-4'>
+            <div className='flex items-center'>
+              <figure>
+                {item.userImage && (
+                  <Image
+                    src={item.userImage}
+                    width={50}
+                    height={50}
+                    alt={`${item.nickname} 프로필 이미지`}
+                  />
+                )}
+              </figure>
+              <Link
+                href={`/userpage/${item.userId}`}
+                className='ml-4 text-[1.125rem]'
+              >
+                {item.nickname}
+              </Link>
+            </div>
+            <>
+              {myFollowing && myFollowing.find((el) => el != item.userId) ? (
+                <ButtonSecondary
+                  onClick={() => onClickFollow(uid, item.userId)}
+                >
+                  팔로우
+                </ButtonSecondary>
+              ) : (
+                ''
+              )}
+            </>
+          </li>
+        )
+      })}
+      {followData?.length === 0 && (
+        <li className='text-center'>팔로워 리스트가 나타납니다.</li>
+      )}
+    </ul>
+  )
+}
+
+export default FollowerList

--- a/src/components/mypage/FollowingList.tsx
+++ b/src/components/mypage/FollowingList.tsx
@@ -1,0 +1,95 @@
+import { getFollowDataFollowing, updateFollow } from '@/shared/mypage/api'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useSession } from 'next-auth/react'
+import React from 'react'
+import ButtonSecondary from './ButtonSecondary'
+import Link from 'next/link'
+import Image from 'next/image'
+
+type FollowProps = {
+  data: string[]
+}
+
+const FollowingList = ({ data }: FollowProps) => {
+  const { data: userSessionInfo } = useSession()
+  const uid = userSessionInfo?.user?.uid as string
+  const queryClient = useQueryClient()
+
+  const {
+    data: followData,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryFn: () => getFollowDataFollowing(uid),
+    queryKey: ['following'],
+    enabled: !!uid,
+  })
+
+  const unFollowMutation = useMutation({
+    mutationFn: updateFollow,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['following'] })
+      queryClient.invalidateQueries({ queryKey: ['mypage'] })
+    },
+  })
+
+  const onClickUnFollow = (userId: string, targetId: string) => {
+    const newData = data.filter((item) => item !== targetId)
+    const targetUserData = followData?.find(
+      (item) => item.userId === targetId,
+    )?.follower
+    const newTargetData = targetUserData?.filter((item) => item !== userId)!
+
+    unFollowMutation.mutate({
+      userId,
+      targetId,
+      followingData: newData,
+      newTargetData,
+    })
+  }
+
+  if (isError) {
+    return '에러가 발생했습니다!'
+  }
+
+  if (isLoading) {
+    return '데이터를 불러오는 중입니다.'
+  }
+
+  return (
+    <ul className='list-none'>
+      {followData?.map((item) => {
+        return (
+          <li key={item.userId} className='flex justify-between py-4'>
+            <div className='flex items-center'>
+              <figure>
+                {item.userImage && (
+                  <Image
+                    src={item.userImage}
+                    width={50}
+                    height={50}
+                    alt={`${item.nickname} 프로필 이미지`}
+                  />
+                )}
+              </figure>
+              <Link
+                href={`/userpage/${item.userId}`}
+                className='ml-4 text-[1.125rem]'
+              >
+                {item.nickname}
+              </Link>
+            </div>
+            <ButtonSecondary onClick={() => onClickUnFollow(uid, item.userId)}>
+              취소
+            </ButtonSecondary>
+          </li>
+        )
+      })}
+      {followData?.length === 0 && (
+        <li className='text-center'>팔로잉 리스트가 나타납니다.</li>
+      )}
+    </ul>
+  )
+}
+
+export default FollowingList

--- a/src/components/mypage/MyInfo.tsx
+++ b/src/components/mypage/MyInfo.tsx
@@ -17,6 +17,8 @@ import { useSession } from 'next-auth/react'
 import right from '@/../public/images/chevron-right.svg'
 import pencil from '@/../public/images/pencil-line.svg'
 import ButtonPrimary from './ButtonPrimary'
+import FollowingList from './FollowingList'
+import FollowerList from './FollowerList'
 
 const MyInfo = () => {
   const { data: userSessionInfo } = useSession()
@@ -160,17 +162,13 @@ const MyInfo = () => {
       id: 0,
       title: '팔로워',
       content: (
-        <FollowList
-          data={data?.follower!}
-          dataKey={'follower'}
-          myFollowing={data?.following!}
-        />
+        <FollowerList data={data?.follower!} myFollowing={data?.following!} />
       ),
     },
     {
       id: 1,
       title: '팔로잉',
-      content: <FollowList data={data?.following!} dataKey={'following'} />,
+      content: <FollowingList data={data?.following!} />,
     },
   ]
 

--- a/src/shared/mypage/api.ts
+++ b/src/shared/mypage/api.ts
@@ -234,6 +234,59 @@ export const getFollowData = async (ids: string[]) => {
   }
 }
 
+export const getFollowDataFollowing = async (userId: string) => {
+  try {
+    const { data } = await supabase
+      .from('userInfo')
+      .select('following')
+      .eq('userId', userId)
+      .limit(1)
+      .single()
+
+    const followingIds = data?.following ? data?.following : []
+
+    const { data: followingData, error } = await supabase
+      .from('userInfo')
+      .select('userId, nickname, userImage,following, follower')
+      .in('userId', followingIds)
+    if (error) {
+      console.error(error)
+      return []
+    }
+
+    return followingData
+  } catch (error) {
+    console.log(error)
+    return []
+  }
+}
+
+export const getFollowDataFollower = async (userId: string) => {
+  try {
+    const { data, error } = await supabase
+      .from('userInfo')
+      .select('follower')
+      .eq('userId', userId)
+      .limit(1)
+      .single()
+
+    const followerIds = data?.follower ? data?.follower : []
+
+    const { data: followerData } = await supabase
+      .from('userInfo')
+      .select('userId, nickname, userImage,following, follower')
+      .in('userId', followerIds)
+    if (error) {
+      console.error(error)
+      return
+    }
+
+    return followerData
+  } catch (error) {
+    console.log(error)
+  }
+}
+
 export const updateFollow = async ({
   userId,
   targetId,


### PR DESCRIPTION
## 📌 관련 이슈 번호
closed #217 

## 요약

팔로잉 리스트 취소 에러 문제 처리를 위한 팔로잉/팔로워 컴포넌트 분리

## PR 유형

- [x] 기능 추가
- [x] 버그 수정

## 작업 내용 상세

- 컴포넌트 분리 및 데이터 조회 api 추가