### PR TITLE
Fix(#279) : 자신의 유저 프로필 페이지 접속 못하도록 로직 추가

### DIFF
--- a/src/components/userpage/UserInfo.tsx
+++ b/src/components/userpage/UserInfo.tsx
@@ -77,6 +77,12 @@ const UserInfo = () => {
     }
   }, [router, status])
 
+  useEffect(() => {
+    if (uid === id) {
+      router.replace('/')
+    }
+  }, [router])
+
   if (isError) {
     return <>에러발생</>
   }


### PR DESCRIPTION
## 📌 관련 이슈 번호
closed #279

## 요약

자신의 유저 페이지에 접속하여 자신을 팔로우하는 문제가 발생하여,
자신의 유저 페이지 접속하지 못하도록 로직 추가

## PR 유형

- [x] 버그 수정

## 작업 내용 상세

- 접속 불가하도록 로직 추가

## 리뷰를 요청할 내용

팀원들의 리뷰가 필요한 내용이 있다면 명시해주세요.

## Trouble Shooting

## Reference (또는 새로 알게 된 내용) 혹은 궁금한 사항들
