### PR TITLE
Style(#327) : 배포 서버와 로컬 서버의 css 우선순위 다른 문제

### DIFF
--- a/src/components/main/GenreMusicItem.tsx
+++ b/src/components/main/GenreMusicItem.tsx
@@ -70,8 +70,8 @@ const GenreMusicItem = ({ item }: { item: GenreMusicInfo }) => {
       className={`mr-6 w-[144px] list-none bg-[#ffffff19] ${itemShadow} overflow-hidden rounded-[2rem] border-4 border-[#00000070] p-2 text-center`}
     >
       <div>
-        <div className='group relative mb-2 h-[120px] w-[120px] overflow-hidden rounded-full border-2 border-[#ffffff19] [&_img]:h-auto [&_img]:w-full'>
-          <figure>
+        <div className='group relative mb-2 h-[120px] w-[120px] overflow-hidden rounded-full border-2 border-[#ffffff19]'>
+          <figure className='h-[120px] w-[120px] [&_img]:h-auto [&_img]:w-full'>
             <Image
               className='group-hover:blur-sm'
               src={item.thumbnail}


### PR DESCRIPTION
## 📌 관련 이슈 번호
closed #327

## 요약

메인 음악추천 아이템 컴포넌트의 배포 서버와 로컬 서버의 css 우선순위가 달라 다르게 스타일링 되는 문제 처리

## PR 유형

- [x] 스타일링

## 작업 내용 상세

- css  클래스 수정

## 리뷰를 요청할 내용

팀원들의 리뷰가 필요한 내용이 있다면 명시해주세요.

## Trouble Shooting

## Reference (또는 새로 알게 된 내용) 혹은 궁금한 사항들

w-full 하위에 이미지는 100프로라는 tailwind 규칙이 있었음... 근데 왜 배포서버랑 로컬서버의 css 우선순위가 다른거지..


왼쪽이 개발서버, 오른쪽이 배포서버

![image](https://github.com/RE-V-UP/vvv/assets/74702206/c1873851-86e7-4ad1-9242-f142a3836796)


![image](https://github.com/RE-V-UP/vvv/assets/74702206/bc78ae61-75dc-439f-9506-352183f9a8c7)
